### PR TITLE
docs: adjust sign key environment variable

### DIFF
--- a/router/security/config-validation-and-signing.md
+++ b/router/security/config-validation-and-signing.md
@@ -63,7 +63,7 @@ Upon receiving the signature, we will associate it with the artifact. The subseq
 ```yaml
 version: '1'
 graph: 
-  sign_key: 'sign_key' # or AUTH_SIGNATURE_KEY 
+  sign_key: 'sign_key' # or GRAPH_CONFIG_SIGN_KEY 
 ```
 {% endcode %}
 


### PR DESCRIPTION
According to the [config](https://github.com/akoenig/cosmo/blob/b9de0a0ccb0636c5b2c1274f60703555dc777da9/router/pkg/config/config.go#L23) in the router, this should be `GRAPH_CONFIG_SIGN_KEY`.