### PR TITLE
fix: Prometheus config example

### DIFF
--- a/router/configuration.md
+++ b/router/configuration.md
@@ -357,7 +357,8 @@ telemetry:
 version: "1"
 
 # See "https://cosmo-docs.wundergraph.com/router/metrics-and-monitoring" for more information
-telemetry:          
+telemetry:
+  metrics:
     # Expose OpenTelemetry metrics for scraping
     prometheus:
       enabled: true


### PR DESCRIPTION
It looks like the config example for Prometheus is missing the metrics section.