### PR TITLE
Fix typo in websocket router configuration

### DIFF
--- a/router/configuration/README.md
+++ b/router/configuration/README.md
@@ -1108,7 +1108,7 @@ engine:
   enable_websocket_epoll_kqueue: true
   epoll_kqueue_poll_timeout: "1s"
   epoll_kqueue_conn_buffer_size: 128
-  websocket_read_timeout: "1s"
+  websocket_client_read_timeout: "1s"
   execution_plan_cache_size: 10000
   minify_subgraph_operations: true
   enable_persisted_operations_cache: true


### PR DESCRIPTION
Looks like the option was renamed in the table, but not in the config sample.