### PR TITLE
Fix incorrect cache control example

### DIFF
--- a/docs/router/proxy-capabilities/adjusting-cache-control.mdx
+++ b/docs/router/proxy-capabilities/adjusting-cache-control.mdx
@@ -100,7 +100,7 @@ The algorithm evaluates the following in order:
 
 #### **Scenario 5: No global default**
 
-* **Global:&#x20;**`enabled: false`
+* **Global:&#x20;**`enabled: true`, `value` unset
 
 * **Subgraph A**: no cache control set
 


### PR DESCRIPTION
If `enabled` is `false` the router doesn't set `Cache-Control` at all.