### PR TITLE
refactor: update titles and descriptions in router documentation

### DIFF
--- a/docs/router/configuration.mdx
+++ b/docs/router/configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Configuration"
-description: "Learn how to configure your router."
+title: "Router Configuration"
+description: "Router Configuration Reference"
 icon: circle-info
 sidebarTitle: Overview
 ---

--- a/docs/router/subscriptions/router-configuration-for-subscriptions.mdx
+++ b/docs/router/subscriptions/router-configuration-for-subscriptions.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Router Configuration For Subscriptions"
+title: "Subscriptions Configuration"
 description: "This section explains how you can configure Subscriptions both for local development and using Cosmo Studio."
 icon: router
+sidebarTitle: "Configuration"
 ---
 
 When using Subscriptions with Cosmo Router locally or through Cosmo Studio, you'd need to configure the correct protocol to talk to your Subgraphs. Cosmo Router Supports WebSockets as well as the SSE (Server-Sent Events) for transport. When using WebSockets, the Router automatically negotiates with the Subgraph what protocol to use. The protocols "graphql-ws" and "graphql-transport-ws" are both supported.


### PR DESCRIPTION
- Changed the title from "Configuration" to "Router Configuration" and updated the description to "Router Configuration Reference" in `configuration.mdx`.
- Modified the title from "Router Configuration For Subscriptions" to "Subscriptions Configuration" and adjusted the description in `router-configuration-for-subscriptions.mdx` for clarity.
- Added a sidebar title "Configuration" for better navigation.