### PR TITLE
feat: enhance documentation for header rules and template expressions

### DIFF
--- a/docs/router/configuration.mdx
+++ b/docs/router/configuration.mdx
@@ -793,6 +793,27 @@ headers:
 
 </CodeGroup>
 
+#### Header Rule Example Using Template Expression:
+
+This example sets the `X-User-ID` header based on the `sub` claim from the JWT token, if the user is authenticated.
+Learn more about [template expressions](/router/configuration/template-expressions).
+
+<CodeGroup>
+
+```yaml config.yaml
+version: "1"
+
+headers:
+  all:
+    request:
+      - op: "set"
+        name: "X-User-ID"
+        # Sets the header only if the user is authenticated
+        expression: "request.auth.isAuthenticated ? request.auth.claims.sub : ''"
+```
+
+</CodeGroup>
+
 ### Request Header Rule
 
 Apply to requests to specific Subgraphs.

--- a/docs/router/configuration/template-expressions.mdx
+++ b/docs/router/configuration/template-expressions.mdx
@@ -6,7 +6,11 @@ icon: "brackets-curly"
 
 ## Template Expressions Overview
 
-Template Expressions are a robust mechanism for accessing information related to requests, responses, and other key aspects of the router's operation. They enable conditional feature activation and allow for extracting and configuring values dynamically. A common use case involves conditionally blocking mutations:
+Template Expressions are a robust mechanism for accessing information related to requests, responses,
+and other key aspects of the router's operation.
+They enable conditional feature activation and allow for extracting and configuring values dynamically.
+
+An example use case involves conditionally blocking mutations:
 
 ```yaml
 security:
@@ -15,9 +19,14 @@ security:
     condition: "request.header.Get('x-block-mutation') == 'yes'"
 ```
 
-In this example, the condition is evaluated each time a request is made. Template Expressions provide access to request details, including headers, URLs, and query parameters. However, not all fields are consistently available throughout the request lifecycle. For instance, authentication data becomes accessible only after successful authentication.
+In this example, the condition is evaluated each time a request is made.
+Template Expressions provide access to request details, including headers, URLs, and query parameters.
+However, not all fields are consistently available throughout the request lifecycle.
+For instance, authentication data becomes accessible only after successful authentication.
 
-During the build process, the router validates expressions. If an expression is invalid or does not return the expected type (such as a boolean or string), an error message is generated to ensure clarity and correctness.
+During the build process, the router validates expressions.
+If an expression is invalid or does not return the expected type (such as a boolean or string),
+an error message is generated to ensure clarity and correctness.
 
 ### Template Language
 
@@ -120,6 +129,11 @@ The `auth` object contains authentication-related information for the request. I
 
 ```bash
 'read:miscellaneous' in request.auth.scopes
+```
+
+---
+
+```
 request.auth.isAuthenticated
 ```
 

--- a/docs/router/proxy-capabilities/request-headers-operations.mdx
+++ b/docs/router/proxy-capabilities/request-headers-operations.mdx
@@ -20,23 +20,31 @@ headers:
       - op: "propagate"            # Forward a client header
         named: X-Test-Header       # Exact match (Use the canonicalized version)
 
+      # Regex match (Case insensitive)
       - op: "propagate"
-        matching: (?i)^X-Custom-.* # Regex match (Case insensitive)
+        matching: (?i)^X-Custom-.*
 
+      # Sets the value when the header was not set
       - op: "propagate"
         named: "X-User-Id"
-        default: "123"             # Set the value when the header was not set
+        default: "123"
 
+      # Rewrites the header from X-Test-1 to X-Test
       - op: "propagate"
         named: "X-Test-1"
-        rename: "X-Test"           # Rewrites the header from X-Test-1 to X-Test
+        rename: "X-Test"
 
       - op: "set"
         name: "X-Custom-Header"
         value: "my-required-key"
 
+      # Dynamic value using template expression
+      - op: "set"
+        name: "X-User-ID"
+        expression: "request.auth.isAuthenticated ? request.auth.claims.sub : ''"
+
   subgraphs:
-    specific-subgraph: # Will only affect this subgraph
+    products: # Will only affect the Subgraph named "products"
       request:
         - op: "propagate"
           named: "Subgraph-Secret"
@@ -57,17 +65,19 @@ Currently, we support the following header rules:
 
   * `named` - It exactly matches on the header name.
 
-  * `matching`**&#x20;-&#x20;**&#x52;egex matches on the header name. You can use[regex101.com](https://regex101.com/) to test your regexes. Go to the website and select `Golang` on the left panel. **Note:** The Router *never* propagates [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Connection`) when propagating by regex.
+  * `matching`**&#x20;-&#x20;**&#x52;egex matches on the header name. You can use [regex101.com](https://regex101.com/) to test your regexes. Go to the website and select `Golang` on the left panel. **Note:** The Router *never* propagates [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Connection`) when propagating by regex.
 
   * `rename`: Replaces the identified header based on its name or matching criteria and transfers the value to the newly specified header.
 
   * `default`: Fallback to this value when the `named`, `matching` or `rename` header could not be found.
 
-* **set** - Sets a header on the request forward to the subgraph. You must set the following values:
+* **set** - Sets a header on the request forward to the subgraph. You must set one of the following:
 
   * `name` - The name of the header to set
 
-  * `value` - The value to set for the header
+  * `value` - The static value to set for the header
+  
+  * `expression` - A [template expression](/router/configuration/template-expressions) that evaluates to the value of the header. For example: `request.auth.isAuthenticated ? request.auth.claims.sub : ''` will set the header to the user's ID if they are authenticated, otherwise an empty string.
 
 <Note>
   Go canonicalizes headers by default e.g. `x-my-header` to `X-My-Header.` Write your rule accordingly or use `(?i)``^X-Test-.*` flags to make your regex case insensitive.


### PR DESCRIPTION
- Added a new section in `configuration.mdx` demonstrating how to set the `X-User-ID` header using a template expression based on the user's authentication status.
- Updated `template-expressions.mdx` to clarify the use of template expressions and their evaluation during the request lifecycle.
- Enhanced `request-headers-operations.mdx` with additional examples for header operations, including dynamic values using template expressions.

This update improves clarity and provides practical examples for users configuring header rules and template expressions in the router.