### PR TITLE
feat: add negate_match feature for propagate regular expressions

### DIFF
--- a/docs/router/proxy-capabilities/request-headers-operations.mdx
+++ b/docs/router/proxy-capabilities/request-headers-operations.mdx
@@ -25,7 +25,7 @@ headers:
         matching: (?i)^X-Custom-.*
 
       - op: "propagate"
-        matching: ^(Header-.*|Key)$
+        matching: ^(Header-1|Key)$
         negate_match: true         # Ensure that all headers except the Header-1 and Key are propagated
 
       # Sets the value when the header was not set

--- a/docs/router/proxy-capabilities/request-headers-operations.mdx
+++ b/docs/router/proxy-capabilities/request-headers-operations.mdx
@@ -24,6 +24,10 @@ headers:
       - op: "propagate"
         matching: (?i)^X-Custom-.*
 
+      - op: "propagate"
+        matching: ^(Header-1|Key)$
+        negative_match: true       # Ensure that all headers except the Header-1 and Key are propagated
+
       # Sets the value when the header was not set
       - op: "propagate"
         named: "X-User-Id"
@@ -61,11 +65,13 @@ The `subgraphs` section allows to propagate headers for specific subgraphs. The 
 
 Currently, we support the following header rules:
 
-* **propagate&#x20;**- Forwards all matching client request headers to the subgraphs. You can choose between one of the following matchers:
+* **propagate** - Forwards all matching client request headers to the subgraphs. You can choose between one of the following matchers:
 
   * `named` - It exactly matches on the header name.
 
-  * `matching`**&#x20;-&#x20;**&#x52;egex matches on the header name. You can use [regex101.com](https://regex101.com/) to test your regexes. Go to the website and select `Golang` on the left panel. **Note:** The Router *never* propagates [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Connection`) when propagating by regex.
+  * `matching` - Regex matches on the header name. You can use [regex101.com](https://regex101.com/) to test your regexes. Go to the website and select `Golang` on the left panel. **Note:** The Router *never* propagates [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Connection`) when propagating by regex.
+
+  * `negate_match` - If set to true, the result of the `matching` regex will be inverted. This is useful for simulating negative lookahead behavior, which is not natively supported.
 
   * `rename`: Replaces the identified header based on its name or matching criteria and transfers the value to the newly specified header.
 

--- a/docs/router/proxy-capabilities/request-headers-operations.mdx
+++ b/docs/router/proxy-capabilities/request-headers-operations.mdx
@@ -25,8 +25,8 @@ headers:
         matching: (?i)^X-Custom-.*
 
       - op: "propagate"
-        matching: ^(Header-1|Key)$
-        negative_match: true       # Ensure that all headers except the Header-1 and Key are propagated
+        matching: ^(Header-.*|Key)$
+        negate_match: true         # Ensure that all headers except the Header-1 and Key are propagated
 
       # Sets the value when the header was not set
       - op: "propagate"

--- a/docs/router/proxy-capabilities/response-header-operations.mdx
+++ b/docs/router/proxy-capabilities/response-header-operations.mdx
@@ -33,7 +33,7 @@ By default, no response headers are forwarded for security reasons. To enable re
 # for the full list of configuration options.
 
 headers:
-  all: # Header rules for all subgraph requests.
+  all: # Header rules for all subgraph responses.
     response:
       - op: "propagate"            # Forward a client header
         named: X-Test-Header       # Exact match (Use the canonicalized version)
@@ -41,6 +41,11 @@ headers:
 
       - op: "propagate"
         matching: (?i)^X-Custom-.* # Regex match (Case insensitive)
+        algorithm: "last_write"
+
+      - op: "propagate"
+        matching: ^(Header-1|Key)$
+        negative_match: true       # Ensure that all headers except the Header-1 and Key are propagated
         algorithm: "last_write"
 
       - op: "propagate"
@@ -71,17 +76,19 @@ The `subgraphs` section allows to propagate headers for specific subgraphs. The 
 
 Currently, we support the following header rules:
 
-* **propagate&#x20;**- Forwards all matching response headers from the subgraphs. You can choose between the following options:
+* **propagate** - Forwards all matching response headers from the subgraphs. You can choose between the following options:
 
-  * **algorithm -&#x20;**&#x54;his defines the algorithm, selecting between `first_write`, `last_write`, and `append`
+  * `algorithm` - This defines the algorithm, selecting between `first_write`, `last_write`, and `append`
 
-  * **named** - It exactly matches on the header name.
+  * `named` - It exactly matches on the header name.
 
-  * **matching -&#x20;**&#x52;egex matches on the header name. You can use[regex101.com](https://regex101.com/) to test your regexes. Go to the website and select `Golang` on the left panel. **Note:** The Router *never* propagates [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Connection`) when propagating by regex.
+  * `matching` - Regex matches on the header name. You can use[regex101.com](https://regex101.com/) to test your regexes. Go to the website and select `Golang` on the left panel. **Note:** The Router *never* propagates [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Connection`) when propagating by regex.
 
-  * **rename**: Replaces the identified header based on its name or matching criteria and transfers the value to the newly specified header.
+  * `negate_match` - If set to true, the result of the `matching` regex will be inverted. This is useful for simulating negative lookahead behavior, which is not natively supported.
 
-  * **default**: Fallback to this value when the `named`, `matching` or `rename` header could not be found.
+  * `rename` - Replaces the identified header based on its name or matching criteria and transfers the value to the newly specified header.
+
+  * `default` - Fallback to this value when the `named`, `matching` or `rename` header could not be found.
 
 * `set` - Sets a header on the request forward to the subgraph. You must set the following values:
 

--- a/docs/router/proxy-capabilities/response-header-operations.mdx
+++ b/docs/router/proxy-capabilities/response-header-operations.mdx
@@ -45,7 +45,7 @@ headers:
 
       - op: "propagate"
         matching: ^(Header-1|Key)$
-        negative_match: true       # Ensure that all headers except the Header-1 and Key are propagated
+        negate_match: true         # Ensure that all headers except the Header-1 and Key are propagated
         algorithm: "last_write"
 
       - op: "propagate"


### PR DESCRIPTION
# Motivation

We introduce `negate_match` as a new attribute because go does not support negative lookahead regexes and we want to allow users a workaround to simulate this.