### PR TITLE
Fix link to gRPC

### DIFF
--- a/docs/cli/grpc-service.mdx
+++ b/docs/cli/grpc-service.mdx
@@ -13,4 +13,4 @@ WunderGraph Cosmo CLI includes commands for working with gRPC services for the C
   </Card>
 </CardGroup>
 
-For detailed documentation about gRPC services and how they work, see the [Router gRPC Services](/router/grpc/grpc-services) documentation. 
+For detailed documentation about gRPC services and how they work, see the [Router gRPC Services](/router/gRPC/grpc-services) documentation. 

--- a/docs/router/gRPC/grpc-services.mdx
+++ b/docs/router/gRPC/grpc-services.mdx
@@ -11,7 +11,7 @@ gRPC services in Cosmo are independent, remotely deployed services that communic
 
 This approach is ideal for distributed architectures where services are owned by different teams, require independent scaling, or need to be implemented in languages other than Go.
 
-For an overview of gRPC concepts shared between plugins and services, see our [gRPC Concepts documentation](/router/grpc/concepts).
+For an overview of gRPC concepts shared between plugins and services, see our [gRPC Concepts documentation](/router/gRPC/concepts).
 
 ## Tutorial
 

--- a/docs/router/gRPC/plugins.mdx
+++ b/docs/router/gRPC/plugins.mdx
@@ -15,7 +15,7 @@ In addition, the Cosmo Router manages the lifecycle of plugins,
 including hot-reloading plugins without any service interruption.
 There's no need to deploy "Subgraph" services just to bring an existing API into your Supergraph.
 
-For an overview of gRPC concepts shared between plugins and services, see our [gRPC Concepts documentation](/router/grpc/concepts).
+For an overview of gRPC concepts shared between plugins and services, see our [gRPC Concepts documentation](/router/gRPC/concepts).
 
 ## Workflow
 


### PR DESCRIPTION
Change grpc to gRPC in doc links. 