### PR TITLE
feat: documentation for response body expressions

### DIFF
--- a/docs/router/access-logs.mdx
+++ b/docs/router/access-logs.mdx
@@ -238,7 +238,7 @@ The response type of the expression is validated upon startup. You should ensure
  Note that while `subgraph` attributes can be accessed in the request logger, it will always have "zero" values.
 </Warning>
 
-##### Subgraph Access Log Expressions
+#### Subgraph Access Log Expressions
 
 <Info>
   Available since Router [0.214.1](https://github.com/wundergraph/cosmo/releases/tag/router%400.214.1)
@@ -255,7 +255,6 @@ access_logs:
 ```
 
 In addition to the router access logger, you can also add attributes to the subgraph access logger, this is useful when you want to log anything related to the `subgraph` expression context object.
-
 
 You can find more information about expressions and the fields accessible for expressions [here](/router/configuration/template-expressions).
 

--- a/docs/router/configuration/template-expressions.mdx
+++ b/docs/router/configuration/template-expressions.mdx
@@ -95,11 +95,11 @@ request.url.query.foo == 'bar' && request.method == 'POST'
 request.header.Get('x-block-mutation') == 'yes'
 ```
 
-### **Body Object**
+### Request Body Object
 
 The body object holds information related to the request body. However, if used in telemetry attribute expressions, it will be empty because the router hasn't read the body at that stage of processing yet.
 
-To optimize performance, the raw request body (`raw.body`) is only included in the expression context if at least one expression explicitly references it.
+To optimize performance, the raw request body (`body.raw`) is only included in the expression context if at least one expression explicitly references it.
 
 **Available Fields**:
 
@@ -151,6 +151,34 @@ It contains the following properties:
 - `subgraph.request.error` (error): Any error that occurred during the subgraph request
 - `subgraph.request.clientTrace` (ClientTrace): Contains tracing information about the client connection
 
+#### SubgraphResponse Properties
+
+- `subgraph.response.body` (SubgraphResponseBody): The subgraph response body as a string
+
+
+### SubgraphResponseBody Object
+
+The subgraph body object holds information related to the response body of the subgraph. 
+
+To optimize performance, the raw response body (`body.raw`) is only included in the expression context if at least one expression explicitly references it.
+
+**Available Fields**:
+
+- `subgraph.response.body.raw`
+
+<Note>
+This attribute will evaluate to `""` when used outside of `access_logs.subgraphs.fields` expressions. You can find more info about subgraph access log fields [here](/router/access-logs#subgraph-access-log-expressions).
+</Note>
+
+
+#### Example expressions
+
+This example returns the raw subgraph response body only when an error occurs for the subgraph request.
+
+```
+subgraph.request.error != nil ? subgraph.response.body.raw : ''
+```
+
 #### ClientTrace Properties
 
 - `subgraph.request.clientTrace.connAcquireDuration` (float64): The duration in seconds it took to acquire the connection to the subgraph
@@ -163,6 +191,35 @@ This object is available in template expressions and can be accessed using the `
 subgraph.name == 'products'
 subgraph.request.error != nil
 subgraph.request.clientTrace.connAcquireDuration > 1.0
+```
+### **Response Object**
+
+The `response` object is a read-only entity that provides details about the outgoing response. It is accessible after the response has been processed by the router.
+
+**Available Fields**:
+
+- `response.body`
+
+### ResponseBody Object
+
+The body object holds information related to the response body. 
+
+To optimize performance, the raw response body (`body.raw`) is only included in the expression context if at least one expression explicitly references it.
+
+**Available Fields**:
+
+- `response.body.raw`
+
+<Note>
+This attribute will evaluate to `""` when used outside of `access_logs.router.fields` expressions. You can find more info about router access log fields [here](/router/access-logs#expression-fields).
+</Note>
+
+#### Example expressions
+
+This example returns the raw response body only when an error occurs, which is useful for debugging when used in access log expressions.
+
+```
+request.error != nil ? response.body.raw : ''
 ```
 
 ### Additional Notes

--- a/docs/router/configuration/template-expressions.mdx
+++ b/docs/router/configuration/template-expressions.mdx
@@ -153,7 +153,7 @@ It contains the following properties:
 
 #### SubgraphResponse Properties
 
-- `subgraph.response.body` (SubgraphResponseBody): The subgraph response body as a string
+- `subgraph.response.body` (SubgraphResponseBody)
 
 
 ### SubgraphResponseBody Object
@@ -164,7 +164,7 @@ To optimize performance, the raw response body (`body.raw`) is only included in 
 
 **Available Fields**:
 
-- `subgraph.response.body.raw`
+- `subgraph.response.body.raw` (string): The raw stringified representation of the subgraph response body
 
 <Note>
 This attribute will evaluate to `""` when used outside of `access_logs.subgraphs.fields` expressions. You can find more info about subgraph access log fields [here](/router/access-logs#subgraph-access-log-expressions).
@@ -198,7 +198,7 @@ The `response` object is a read-only entity that provides details about the outg
 
 **Available Fields**:
 
-- `response.body`
+- `response.body` (ResponseBody)
 
 ### ResponseBody Object
 
@@ -208,7 +208,7 @@ To optimize performance, the raw response body (`body.raw`) is only included in 
 
 **Available Fields**:
 
-- `response.body.raw`
+- `response.body.raw` (string): The raw stringified representation of the router response body
 
 <Note>
 This attribute will evaluate to `""` when used outside of `access_logs.router.fields` expressions. You can find more info about router access log fields [here](/router/access-logs#expression-fields).


### PR DESCRIPTION
This PR adds documentation for the following

* subgraph response body
* global response body