### PR TITLE
Document experimental config options and stability policy

### DIFF
--- a/docs/router/configuration.mdx
+++ b/docs/router/configuration.mdx
@@ -19,7 +19,7 @@ The router provides three different ways of customization:
 <Warning>
   **Experimental options** 
 
-  Options starting with the prefix `experiment_` are unstable, and do not fall under any API stability guaruntees. They may be updated or removed in future versions without a deprecation notice.
+  Options starting with the prefix `experiment_` are unstable, and do not fall under any API stability guarantees. They may be updated or removed in future versions without a deprecation notice.
 </Warning>
 
 ## Config File


### PR DESCRIPTION
Adds an explanation of the `experiment_` prefix and how it affects stability guarantees 