### PR TITLE
chore: update cli/namespace/create 

### DIFF
--- a/docs/cli/namespace/create.mdx
+++ b/docs/cli/namespace/create.mdx
@@ -4,15 +4,16 @@ description: "Creates a namespace for the organization on the control plane"
 icon: plus
 ---
 
+## Description
+The `npx wgc namespace create` command allows you to create a new namespace within the organization.
+
+<Info>Namespaces must be created before they can be used. For example, you need to create a namespace before adding a graph to it.</Info>
+
 ## Usage
 
 ```bash
 npx wgc namespace create [name]
 ```
-
-## Description
-
-The `npx wgc namespace create` command allows you to create a new namespace within the organization.
 
 ## **Parameters**
 


### PR DESCRIPTION
The description section is moved up in `cli/namespace/create` and an info box that namespaces must be created before they can be used was added, per customer request.