### PR TITLE
Remove rocket, move local dev back to top

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -49,15 +49,8 @@
             "group": "Getting Started",
             "pages": [
               "getting-started/cosmo-cloud-onboarding",
-              "getting-started/switch-from-apollo-to-cosmo"
-            ]
-          },
-          {
-            "group": "🚀 Cosmo Connect",
-            "pages": [
-              "connect/overview",
-              "connect/plugins",
-              "connect/grpc-services"
+              "getting-started/switch-from-apollo-to-cosmo",
+              "tutorial/mastering-local-development-for-graphql-federation"
             ]
           },
           {
@@ -69,6 +62,14 @@
               "concepts/schema-contracts",
               "concepts/cache-warmer",
               "concepts/router-compatibility-versions"
+            ]
+          },
+          {
+            "group": "Cosmo Connect",
+            "pages": [
+              "connect/overview",
+              "connect/plugins",
+              "connect/grpc-services"
             ]
           },
           {
@@ -622,11 +623,11 @@
             "group": "Tutorials",
             "pages": [
               "tutorial",
+              "tutorial/mastering-local-development-for-graphql-federation",
+              "tutorial/from-zero-to-federation-in-5-steps-using-cosmo",
               "tutorial/using-grpc-plugins",
               "tutorial/grpc-service-quickstart",
               "tutorial/deploy-federated-graphql-with-confidence",
-              "tutorial/from-zero-to-federation-in-5-steps-using-cosmo",
-              "tutorial/mastering-local-development-for-graphql-federation",
               "tutorial/composing-graphs",
               "tutorial/pr-based-workflow-for-federation",
               "tutorial/otel-instrumentation-on-subgraphs",

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -5,13 +5,13 @@ icon: circle-info
 ---
 
 <CardGroup>
+  <Card title="Mastering Local Development for GraphQL Federation" icon="code" href="/tutorial/mastering-local-development-for-graphql-federation" horizontal/>
+  
+  <Card title="From Zero to Federation in 5 Steps using Cosmo" icon="rocket" href="/tutorial/from-zero-to-federation-in-5-steps-using-cosmo" horizontal/>
+  
   <Card title="Deploy Your First Router Plugin" icon="plug" href="/tutorial/using-grpc-plugins" horizontal/>
 
   <Card title="Deploy Your First gRPC Service" icon="plug" href="/tutorial/grpc-service-quickstart" horizontal/>
-
-  <Card title="From Zero to Federation in 5 Steps using Cosmo" icon="rocket" href="/tutorial/from-zero-to-federation-in-5-steps-using-cosmo" horizontal/>
-
-  <Card title="Mastering Local Development for GraphQL Federation" icon="code" href="/tutorial/mastering-local-development-for-graphql-federation" horizontal/>
 
   <Card title="Composing Graphs" icon="network-wired" href="/tutorial/composing-graphs" horizontal/>
 


### PR DESCRIPTION
This moves Cosmo Connect and removes the rocket.

It also reorders the tutorials so the beginner ones are at the top again.