### PR TITLE
feat(router): document TLS support for NATS event source

### DIFF
--- a/docs/router/cosmo-streams/nats.mdx
+++ b/docs/router/cosmo-streams/nats.mdx
@@ -96,6 +96,55 @@ Based on the example above, you will need a compatible router configuration.
   ```
 </CodeGroup>
 
+### TLS
+
+The NATS provider supports four TLS modes:
+
+| Mode | Config |
+|---|---|
+| No TLS | Omit the `tls` block |
+| TLS with skip verify | `insecure_skip_verify: true` |
+| TLS with custom CA | `ca_file: /path/to/ca.crt` |
+| Mutual TLS (mTLS) | `ca_file` + `cert_file` + `key_file` |
+
+<CodeGroup>
+  ```yaml Skip verify (dev/self-signed)
+  events:
+    providers:
+      nats:
+        - id: my-nats
+          url: "nats://localhost:4222"
+          tls:
+            insecure_skip_verify: true
+  ```
+
+  ```yaml Custom CA (1-way TLS)
+  events:
+    providers:
+      nats:
+        - id: my-nats
+          url: "nats://localhost:4222"
+          tls:
+            ca_file: /path/to/ca.crt
+  ```
+
+  ```yaml Mutual TLS (mTLS)
+  events:
+    providers:
+      nats:
+        - id: my-nats
+          url: "nats://localhost:4222"
+          tls:
+            ca_file: /path/to/ca.crt
+            cert_file: /path/to/client.crt
+            key_file: /path/to/client.key
+  ```
+</CodeGroup>
+
+<Warning>
+  `insecure_skip_verify: true` disables server certificate verification. Do not use in production.
+</Warning>
+
 ## Example Query
 
 In the example query below, one or more subgraphs have been implemented alongside the Event-Driven Graph to resolve any other fields defined on `Employee`, e.g., `tag` and `details.surname`.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added comprehensive TLS configuration guide for NATS provider, including supported encryption modes, practical setup examples, and production security recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds TLS documentation to the NATS event source configuration page, introduced in wundergraph/cosmo#<PR-NUMBER>.

Documents all four supported modes via a mode table and tabbed `CodeGroup` examples:
- No TLS (omit block)
- Skip verify (`insecure_skip_verify: true`)
- Custom CA (`ca_file`)
- Mutual TLS (`ca_file` + `cert_file` + `key_file`)

## Checklist

- [ ] I have validated my changes locally using `mintlify dev`
- [ ] I have validated my changes are working as expected by looking at the preview deployment
- [x] All links in my documentation work correctly
- [x] All images render properly
- [x] Code examples are tested and formatted correctly
- [x] If I added new pages, they are included in the navigation (docs.json)
